### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ This is a simple Android M-PESA SDK to allow you to integrate Safaricom M-PESA A
 
 > This version only offers the MPESA Express (STKPush) Support.
 
-> I will be having Kotlin support soon also, as well as examples!
-
 > If you were using `1.0.0`, be warned that version `1.0.2` ***breaks the code***. Look at the updated example
 
 ## Getting Started


### PR DESCRIPTION
Removed a reduntant statement  "I will be having Kotlin support soon also, as well as examples!". About 90% of the library is in Kotlin and the given example is in Kotlin. Beginners will think the library support only  Java