### PR TITLE
PaymentViewmodel unit tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -125,6 +125,6 @@ dependencies {
     testImplementation(TestLibraries.runner)
     testImplementation(TestLibraries.androidXJUnit)
     testImplementation(TestLibraries.archComponentTest)
-    testImplementation(TestLibraries.liveDataTesting)
+//    testImplementation(TestLibraries.liveDataTesting)
     testImplementation(TestLibraries.kotlinxCoroutines)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,4 +126,5 @@ dependencies {
     testImplementation(TestLibraries.androidXJUnit)
     testImplementation(TestLibraries.archComponentTest)
     testImplementation(TestLibraries.liveDataTesting)
+    testImplementation(TestLibraries.kotlinxCoroutines)
 }

--- a/app/src/main/java/com/androidstudy/mpesa/di/AppComponent.kt
+++ b/app/src/main/java/com/androidstudy/mpesa/di/AppComponent.kt
@@ -23,7 +23,8 @@ import dagger.android.support.AndroidSupportInjectionModule
 import javax.inject.Singleton
 
 @Singleton
-@Component(modules = [AndroidSupportInjectionModule::class, ViewModelModule::class, ActivitiesModule::class, AppModule::class])
+@Component(modules = [AndroidSupportInjectionModule::class, ViewModelModule::class,
+    ActivitiesModule::class, AppModule::class, RepositoryModule::class])
 interface AppComponent : AndroidInjector<DaggerApplication> {
     fun inject(app: MpesaExpressApp)
 }

--- a/app/src/main/java/com/androidstudy/mpesa/di/RepositoryModule.kt
+++ b/app/src/main/java/com/androidstudy/mpesa/di/RepositoryModule.kt
@@ -1,0 +1,16 @@
+package com.androidstudy.mpesa.di
+
+import com.androidstudy.mpesa.repo.PaymentRepository
+import com.androidstudy.mpesa.repo.Repository
+import dagger.Binds
+import dagger.Module
+
+/**
+ * Created by Andronicus Kim on 8/20/21.
+ */
+@Module
+abstract class RepositoryModule {
+
+    @Binds
+    abstract fun bindRepository(paymentRepository: PaymentRepository) : Repository
+}

--- a/app/src/main/java/com/androidstudy/mpesa/repo/PaymentRepository.kt
+++ b/app/src/main/java/com/androidstudy/mpesa/repo/PaymentRepository.kt
@@ -22,12 +22,12 @@ import com.androidstudy.mpesa.common.DarajaPaymentLiveData
 import com.androidstudy.mpesa.utils.AppUtils
 import javax.inject.Inject
 
-class PaymentRepository @Inject constructor() {
+class PaymentRepository @Inject constructor() : Repository{
 
     @Inject
     lateinit var daraja: Daraja
 
-    val accessToken: DarajaLiveData<AccessToken>
+    override val accessToken: DarajaLiveData<AccessToken>
         get() {
             val accessTokenLiveData = DarajaLiveData<AccessToken>()
             daraja.getAccessToken(accessTokenLiveData)
@@ -35,7 +35,8 @@ class PaymentRepository @Inject constructor() {
             return accessTokenLiveData
         }
 
-    fun initiatePayment(token: String, phoneNumber: String, amount: Int, description: String): DarajaPaymentLiveData {
+
+    override fun initiatePayment(token: String, phoneNumber: String, amount: Int, description: String): DarajaPaymentLiveData {
         val listener = DarajaPaymentLiveData()
 
         daraja.initiatePayment(

--- a/app/src/main/java/com/androidstudy/mpesa/repo/Repository.kt
+++ b/app/src/main/java/com/androidstudy/mpesa/repo/Repository.kt
@@ -1,0 +1,14 @@
+package com.androidstudy.mpesa.repo
+
+import com.androidstudy.daraja.model.AccessToken
+import com.androidstudy.mpesa.common.DarajaLiveData
+import com.androidstudy.mpesa.common.DarajaPaymentLiveData
+
+/**
+ * Created by Andronicus Kim on 8/20/21.
+ */
+interface Repository {
+    val accessToken: DarajaLiveData<AccessToken>
+
+    fun initiatePayment(token: String, phoneNumber: String, amount: Int, description: String): DarajaPaymentLiveData
+}

--- a/app/src/main/java/com/androidstudy/mpesa/viewmodel/PaymentViewModel.kt
+++ b/app/src/main/java/com/androidstudy/mpesa/viewmodel/PaymentViewModel.kt
@@ -21,11 +21,12 @@ import com.androidstudy.daraja.model.AccessToken
 import com.androidstudy.mpesa.common.DarajaLiveData
 import com.androidstudy.mpesa.common.DarajaPaymentLiveData
 import com.androidstudy.mpesa.repo.PaymentRepository
+import com.androidstudy.mpesa.repo.Repository
 import javax.inject.Inject
 
 class PaymentViewModel @Inject
 internal constructor(
-    private val paymentRepository: PaymentRepository
+    private val paymentRepository: Repository
 ) : ViewModel() {
 
     fun initiatePayment(token: String, phone: String, amount: Int, description: String): DarajaPaymentLiveData =

--- a/app/src/test/java/com/androidstudy/mpesa/LiveDataUtilTest.kt
+++ b/app/src/test/java/com/androidstudy/mpesa/LiveDataUtilTest.kt
@@ -1,0 +1,51 @@
+package com.androidstudy.mpesa
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Created by Andronicus Kim on 8/19/21.
+ */
+
+/**
+ * Gets the value of a [LiveData] or waits for it to have one, with a timeout.
+ *
+ * Use this extension from host-side (JVM) tests. It's recommended to use it alongside
+ * `InstantTaskExecutorRule` or a similar mechanism to execute tasks synchronously.
+ */
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+fun <T> LiveData<T>.getOrAwaitValueTest(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+    afterObserve: () -> Unit = {}
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(o: T?) {
+            data = o
+            latch.countDown()
+            this@getOrAwaitValueTest.removeObserver(this)
+        }
+    }
+    this.observeForever(observer)
+
+    try {
+        afterObserve.invoke()
+
+        // Don't wait indefinitely if the LiveData is not set.
+        if (!latch.await(time, timeUnit)) {
+            throw TimeoutException("LiveData value was never set.")
+        }
+
+    } finally {
+        this.removeObserver(observer)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/app/src/test/java/com/androidstudy/mpesa/MainCoroutineRule.kt
+++ b/app/src/test/java/com/androidstudy/mpesa/MainCoroutineRule.kt
@@ -1,0 +1,31 @@
+package com.androidstudy.mpesa
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * Created by Andronicus Kim on 8/19/21.
+ */
+@ExperimentalCoroutinesApi
+class MainCoroutineRule(
+    private val dispatcher: CoroutineDispatcher = TestCoroutineDispatcher()
+) : TestWatcher(), TestCoroutineScope by TestCoroutineScope(dispatcher) {
+
+    override fun starting(description: Description?) {
+        super.starting(description)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description?) {
+        super.finished(description)
+        cleanupTestCoroutines()
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/androidstudy/mpesa/repo/FakePaymentRepository.kt
+++ b/app/src/test/java/com/androidstudy/mpesa/repo/FakePaymentRepository.kt
@@ -14,8 +14,15 @@ class FakePaymentRepository : Repository{
     //Flag to control network response
     private var shouldReturnNetworkError = false
 
+    //Flag to control api response
+    private var shouldReturnApiError = false
+
     fun setShouldReturnNetworkError(value: Boolean) {
         shouldReturnNetworkError = value
+    }
+
+    fun setShouldReturnApiError(value: Boolean){
+        shouldReturnApiError = value
     }
 
     override val accessToken: DarajaLiveData<AccessToken>
@@ -27,7 +34,11 @@ class FakePaymentRepository : Repository{
         if (shouldReturnNetworkError){
             listener.onNetworkFailure(DarajaException(""))
         }else {
-            listener.onPaymentRequestComplete(PaymentResult("", "", "", "", ""))
+            if (shouldReturnApiError){
+                listener.onPaymentFailure(DarajaException(""))
+            }else{
+                listener.onPaymentRequestComplete(PaymentResult("", "", "", "", ""))
+            }
         }
 
         return listener

--- a/app/src/test/java/com/androidstudy/mpesa/repo/FakePaymentRepository.kt
+++ b/app/src/test/java/com/androidstudy/mpesa/repo/FakePaymentRepository.kt
@@ -1,6 +1,8 @@
 package com.androidstudy.mpesa.repo
 
+import com.androidstudy.daraja.callback.DarajaException
 import com.androidstudy.daraja.model.AccessToken
+import com.androidstudy.daraja.model.PaymentResult
 import com.androidstudy.mpesa.common.DarajaLiveData
 import com.androidstudy.mpesa.common.DarajaPaymentLiveData
 
@@ -20,6 +22,14 @@ class FakePaymentRepository : Repository{
         get() = DarajaLiveData<AccessToken>()
 
     override fun initiatePayment(token: String, phoneNumber: String, amount: Int, description: String): DarajaPaymentLiveData{
-        return DarajaPaymentLiveData()
+        val listener = DarajaPaymentLiveData()
+
+        if (shouldReturnNetworkError){
+            listener.onNetworkFailure(DarajaException(""))
+        }else {
+            listener.onPaymentRequestComplete(PaymentResult("", "", "", "", ""))
+        }
+
+        return listener
     }
 }

--- a/app/src/test/java/com/androidstudy/mpesa/repo/FakePaymentRepository.kt
+++ b/app/src/test/java/com/androidstudy/mpesa/repo/FakePaymentRepository.kt
@@ -37,7 +37,8 @@ class FakePaymentRepository : Repository{
             if (shouldReturnApiError){
                 listener.onPaymentFailure(DarajaException("Api error"))
             }else{
-                listener.onPaymentRequestComplete(PaymentResult("", "", "", "", ""))
+                listener.onPaymentRequestComplete(PaymentResult("MerchantRequestID", "CheckoutRequestID",
+                    "ResponseCode", "ResponseDescription", "CustomerMessage"))
             }
         }
 

--- a/app/src/test/java/com/androidstudy/mpesa/repo/FakePaymentRepository.kt
+++ b/app/src/test/java/com/androidstudy/mpesa/repo/FakePaymentRepository.kt
@@ -32,10 +32,10 @@ class FakePaymentRepository : Repository{
         val listener = DarajaPaymentLiveData()
 
         if (shouldReturnNetworkError){
-            listener.onNetworkFailure(DarajaException(""))
+            listener.onNetworkFailure(DarajaException("Network error"))
         }else {
             if (shouldReturnApiError){
-                listener.onPaymentFailure(DarajaException(""))
+                listener.onPaymentFailure(DarajaException("Api error"))
             }else{
                 listener.onPaymentRequestComplete(PaymentResult("", "", "", "", ""))
             }

--- a/app/src/test/java/com/androidstudy/mpesa/repo/FakePaymentRepository.kt
+++ b/app/src/test/java/com/androidstudy/mpesa/repo/FakePaymentRepository.kt
@@ -1,0 +1,25 @@
+package com.androidstudy.mpesa.repo
+
+import com.androidstudy.daraja.model.AccessToken
+import com.androidstudy.mpesa.common.DarajaLiveData
+import com.androidstudy.mpesa.common.DarajaPaymentLiveData
+
+/**
+ * Created by Andronicus Kim on 8/19/21.
+ */
+class FakePaymentRepository : Repository{
+
+    //Flag to control network response
+    private var shouldReturnNetworkError = false
+
+    fun setShouldReturnNetworkError(value: Boolean) {
+        shouldReturnNetworkError = value
+    }
+
+    override val accessToken: DarajaLiveData<AccessToken>
+        get() = DarajaLiveData<AccessToken>()
+
+    override fun initiatePayment(token: String, phoneNumber: String, amount: Int, description: String): DarajaPaymentLiveData{
+        return DarajaPaymentLiveData()
+    }
+}

--- a/app/src/test/java/com/androidstudy/mpesa/viewmodel/PaymentViewModelTest.kt
+++ b/app/src/test/java/com/androidstudy/mpesa/viewmodel/PaymentViewModelTest.kt
@@ -48,4 +48,14 @@ class PaymentViewModelTest {
 
         assertThat(result.status()).isEqualTo(Status.ERROR)
     }
+
+    @Test
+    fun `successful network call with an api error returns ERROR enum`(){
+        //set api to return an error
+        repository.setShouldReturnApiError(true)
+
+        val result = viewModel.initiatePayment("","",0,"").getOrAwaitValueTest()
+
+        assertThat(result.status()).isEqualTo(Status.ERROR)
+    }
 }

--- a/app/src/test/java/com/androidstudy/mpesa/viewmodel/PaymentViewModelTest.kt
+++ b/app/src/test/java/com/androidstudy/mpesa/viewmodel/PaymentViewModelTest.kt
@@ -1,0 +1,30 @@
+package com.androidstudy.mpesa.viewmodel
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.androidstudy.mpesa.MainCoroutineRule
+import com.androidstudy.mpesa.repo.FakePaymentRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Rule
+
+/**
+ * Created by Andronicus Kim on 8/19/21.
+ */
+class PaymentViewModelTest {
+
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @ExperimentalCoroutinesApi
+    @get:Rule
+    var mainCoroutineRule = MainCoroutineRule()
+
+    private lateinit var repository: FakePaymentRepository
+    private lateinit var viewModel: PaymentViewModel
+
+    @Before
+    fun setUp() {
+        repository = FakePaymentRepository()
+        viewModel = PaymentViewModel(repository)
+    }
+}

--- a/app/src/test/java/com/androidstudy/mpesa/viewmodel/PaymentViewModelTest.kt
+++ b/app/src/test/java/com/androidstudy/mpesa/viewmodel/PaymentViewModelTest.kt
@@ -2,10 +2,14 @@ package com.androidstudy.mpesa.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.androidstudy.mpesa.MainCoroutineRule
+import com.androidstudy.mpesa.common.Status
+import com.androidstudy.mpesa.getOrAwaitValueTest
 import com.androidstudy.mpesa.repo.FakePaymentRepository
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
 import org.junit.Rule
+import org.junit.Test
 
 /**
  * Created by Andronicus Kim on 8/19/21.
@@ -26,5 +30,22 @@ class PaymentViewModelTest {
     fun setUp() {
         repository = FakePaymentRepository()
         viewModel = PaymentViewModel(repository)
+    }
+
+    @Test
+    fun `successful network call returns SUCCESS enum`(){
+        val result = viewModel.initiatePayment("","",0,"").getOrAwaitValueTest()
+
+        assertThat(result.status()).isEqualTo(Status.SUCCESS)
+    }
+
+    @Test
+    fun `unsuccessful network call returns ERROR enum`(){
+        //set network to return an error
+        repository.setShouldReturnNetworkError(true)
+
+        val result = viewModel.initiatePayment("","",0,"").getOrAwaitValueTest()
+
+        assertThat(result.status()).isEqualTo(Status.ERROR)
     }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -49,6 +49,7 @@ object Versions {
     const val kakao = "2.3.4"
     const val mockK = "1.10.0"
     const val liveDataTesting = "1.1.2"
+    const val kotlinxCoroutines = "1.2.1"
 }
 
 object BuildPlugins {
@@ -116,12 +117,12 @@ object TestLibraries {
     const val androidXTestCore = "androidx.test:core:${Versions.androidXTestCore}"
     const val runner = "androidx.test:runner:${Versions.runner}"
     const val rules = "androidx.test:rules:${Versions.rules}"
-    const val archComponentTest =
-            "androidx.arch.core:core-testing:${Versions.archComponentTest}"
+    const val archComponentTest = "androidx.arch.core:core-testing:${Versions.archComponentTest}"
     const val kakao = "com.agoda.kakao:kakao:${Versions.kakao}"
     const val mockK = "io.mockk:mockk:${Versions.mockK}"
     const val androidMockK = "io.mockk:mockk-android:${Versions.mockK}"
     const val liveDataTesting = "com.jraska.livedata:testing-ktx:${Versions.liveDataTesting}"
+    const val kotlinxCoroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinxCoroutines}"
 }
 
 object BuildModules {


### PR DESCRIPTION
- Adds network call unit tests for PaymentViewmodel
- Jraska live-data testing dependency fails when you run unit tests. Since it's not being used, I commented it out for now to allow us run the tests
- I also added a repository interface to allow PaymentViewmodel to work with both a real and fake PaymentRepository